### PR TITLE
Include utils function for converting viewer state into encoded url for the browser

### DIFF
--- a/ngtools/utils.py
+++ b/ngtools/utils.py
@@ -75,12 +75,10 @@ def neuroglancer_state_to_neuroglancer_url(
     Takes the current State of the Neuroglancer Viewer and converts it into a url-encoded value for the browser
 
     """
-    ordered_dict = state._json_data
-    # Convert the OrderedDict to a regular dictionary
-    dict_data = json.loads(json.dumps(ordered_dict))
+    ordered_dict = state.to_json()
 
     # Convert the dictionary to a JSON string
-    json_str = json.dumps(dict_data)
+    json_str = json.dumps(ordered_dict)
 
     # URL-encode the JSON string
     encoded_json = quote(json_str)

--- a/ngtools/utils.py
+++ b/ngtools/utils.py
@@ -1,3 +1,6 @@
+import json
+from urllib.parse import quote
+
 class bcolors:
 
     # To add color in the input prompt, all delimiter must be wrapped
@@ -62,3 +65,25 @@ class bcolors:
     okgreen = fg.bright.green
     warning = fg.bright.yellow
     fail = fg.bright.red
+
+
+def neuroglancer_state_to_neuroglancer_url(
+        state,
+        base_url="https://neuroglancer.lincbrain.org/cloudfront/frontend/index.html"
+):
+    """
+    Takes the current State of the Neuroglancer Viewer and converts it into a url-encoded value for the browser
+
+    """
+    ordered_dict = state._json_data
+    # Convert the OrderedDict to a regular dictionary
+    dict_data = json.loads(json.dumps(ordered_dict))
+
+    # Convert the dictionary to a JSON string
+    json_str = json.dumps(dict_data)
+
+    # URL-encode the JSON string
+    encoded_json = quote(json_str)
+
+    # Construct and return the full URL
+    return f"{base_url}#!{encoded_json}"


### PR DESCRIPTION
This function allows a researcher to pass the `state` object from the `neuroglancer.Viewer` and create a encoded URL that can be passed around

Here is an example usage:

```
from ngtools.utils import neuroglancer_state_to_neuroglancer_url

global_server_args['bind_port'] = '9999'
viewer = ng.Viewer(token='1')

with viewer.txn() as state:
    state.layers.append(
        name="mri",
        layer=ng.ImageLayer(
            source=["nifti://" + NII],
            shader=mri_shader,
        )
    )
    state.layers.append(
        name="hip-ct",
        layer=ng.ImageLayer(
            source=ng.LayerDataSource(
              url="zarr://" + HIP,
              transform=hip_transform
            ),
            shader=hip_shader,
        )
    )
    print(neuroglancer_state_to_neuroglancer_url(state, <some-url-here>)
```

The value printed should be the URL that would render the layers in a given browser

Cc @balbasty @satra @kabilar @ayendiki