### PR TITLE
FEAT: save "default-to-current" transform

### DIFF
--- a/ngtools/datasources.py
+++ b/ngtools/datasources.py
@@ -323,6 +323,10 @@ class LayerDataSource(Wraps(ng.LayerDataSource),
             return None
         return url
 
+    @property
+    def __default_transform__(self) -> ng.CoordinateSpaceTransform:
+        return getattr(self, '_transform', None)
+
     def __get_transform__(self) -> ng.CoordinateSpaceTransform:
         """
         If a transform has been explicitely set, return it,

--- a/ngtools/local/viewer.py
+++ b/ngtools/local/viewer.py
@@ -462,7 +462,7 @@ class LocalNeuroglancer(OSMixin):
         _ = add_parser('transform', help='Apply a transform')
         _.set_defaults(func=self.transform)
         _.add_argument(
-            dest='transform', nargs='+', metavar='TRANSFORM',
+            dest='transform', nargs='*', metavar='TRANSFORM',
             help='Path to transform file or flattened transformation '
                  'matrix (row major)')
         _.add_argument(
@@ -472,9 +472,22 @@ class LocalNeuroglancer(OSMixin):
             '--inv', '-i', action='store_true', default=False,
             help='Invert the transform before applying it')
         _.add_argument(
+            '--reset', '-r', action='store_true', default=False,
+            help="Reset the layer's transform before applying the new one")
+        _.add_argument(
             '--mov', '-m', help='Moving image (required by some formats)')
         _.add_argument(
             '--fix', '-f', help='Fixed image (required by some formats)')
+
+        # Save current transform
+        _ = add_parser('save_transform', help='Save the current transform')
+        _.set_defaults(func=self.save_transform)
+        _.add_argument(
+            dest='output', nargs='*', help='Path to output transform.')
+        _.add_argument(
+            '--layer', '-l', nargs='+', help='Name(s) of layer(s) to save')
+        _.add_argument(
+            '--format', '-f', help='Format to save into')
 
         # --------------------------------------------------------------
         #   AXIS MODE
@@ -684,6 +697,7 @@ class LocalNeuroglancer(OSMixin):
     space = state_action("space")
     display = state_action("display")
     transform = state_action("transform")
+    save_transform = state_action("save_transform")
     channel_mode = state_action("channel_mode")
     move = state_action("move")
     zoom = state_action("zoom")

--- a/ngtools/transforms.py
+++ b/ngtools/transforms.py
@@ -196,6 +196,19 @@ def inverse_quaternions(a: np.ndarray) -> np.ndarray:
     return a
 
 
+def ras2transform(
+    ras2ras: np.ndarray,
+    names: list[str] = ("x", "y", "z"),
+) -> ng.CoordinateSpaceTransform:
+    """Convert a RAS2RAS matrix (in mm space) to a neuroglancer transform."""
+    dims = ng.CoordinateSpace(names=names, scales=[1]*3, units=["mm"]*3)
+    return ng.CoordinateSpaceTransform(
+        matrix=ras2ras[:3],
+        input_dimensions=dims,
+        output_dimensions=dims,
+    )
+
+
 def load_affine(
     fileobj: IO | PathLike | str,
     format: str | None = None,

--- a/ngtools/utils.py
+++ b/ngtools/utils.py
@@ -78,11 +78,7 @@ def Wraps(kls: type) -> type:
                 if name.startswith("__"):
                     return value
                 if value is None:
-                    has_default = hasattr(self, f"__default_{name}__")
-                    if has_default:
-                        value = getattr(self, f"__default_{name}__")
-                        setattr(self, name, value)
-                        value = getattr(self._wrapped, name)
+                    value = getattr(self, f"__default_{name}__", value)
                 return value
 
             def __getattribute__(self, name: str) -> object:


### PR DESCRIPTION
This feature computes the effective transformation that has been applied to a layer by factoring out the original (default) transformation.

It is useful in itself, as one may modify the transformation matrix in the UI and later save  it in an LTA that can be applied to the original file.

It is also a prerequisite to a future feature that will let the user manually align two layers using landmarks and/or sliders.